### PR TITLE
Fix filesContainer

### DIFF
--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -182,8 +182,7 @@
       if @options.files_container_selector? and $(@options.files_container_selector).length > 0
         @$filesContainer = $(@options.files_container_selector)
       else
-        @$filesContainer = $('<div class="attachinary_container">')
-        @$input.after @$filesContainer
+        @$filesContainer = $('#' + @$input.attr('id') + '_attachinary')
 
     redraw: ->
       @$filesContainer.empty()

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.4.3".freeze
+  VERSION = "1.4.4".freeze
 end


### PR DESCRIPTION
- `f.attachinary_file_field` が同じFormに複数ある場合、`.attachinary_container` を持つ全てのDOMに画像を添付してしまう
- そこで、`id`属性を付与し、`id`属性と`.attachinary_container`のセットで、DOMを一意に特定するように変更する
